### PR TITLE
Fixed membersCreate function for lists

### DIFF
--- a/lib/api/lists/lists_service.dart
+++ b/lib/api/lists/lists_service.dart
@@ -670,7 +670,7 @@ class ListsService {
       ..addParameter('screen_name', screenName);
 
     await client.post(
-      Uri.https('api.twitter.com', '1.1/lists/members/create'),
+      Uri.https('api.twitter.com', '1.1/lists/members/create.json'),
       body: body,
     );
   }


### PR DESCRIPTION
There was a missing ".json" on the membersCreate function under listsService.
From:
`
await client.post(
  Uri.https('api.twitter.com', '1.1/lists/members/create'),
  body: body,
);
`
To:
`
await client.post(
  Uri.https('api.twitter.com', '1.1/lists/members/create.json'),
  body: body,
);
`