### PR TITLE
Adding Count to Query Parameters of Reweets service

### DIFF
--- a/lib/api/tweets/tweet_service.dart
+++ b/lib/api/tweets/tweet_service.dart
@@ -341,7 +341,7 @@ class TweetService {
   }) {
     final params = <String, String>{}
       ..addParameter('trim_user', trimUser)
-      ..addParameter('count', count ?? 100)
+      ..addParameter('count', count)
       ..addParameter('tweet_mode', tweetMode);
 
     return client

--- a/lib/api/tweets/tweet_service.dart
+++ b/lib/api/tweets/tweet_service.dart
@@ -341,6 +341,7 @@ class TweetService {
   }) {
     final params = <String, String>{}
       ..addParameter('trim_user', trimUser)
+      ..addParameter('count', count ?? 100)
       ..addParameter('tweet_mode', tweetMode);
 
     return client

--- a/test/api/tweets/tweet_service_test.dart
+++ b/test/api/tweets/tweet_service_test.dart
@@ -133,7 +133,7 @@ void main() {
       Uri.https(
         'api.twitter.com',
         '1.1/statuses/retweets/912456.json',
-        {'count': '100', 'tweet_mode': 'extended'},
+        {'tweet_mode': 'extended'},
       ),
     )).thenAnswer(
       (_) async => Response(

--- a/test/api/tweets/tweet_service_test.dart
+++ b/test/api/tweets/tweet_service_test.dart
@@ -133,7 +133,7 @@ void main() {
       Uri.https(
         'api.twitter.com',
         '1.1/statuses/retweets/912456.json',
-        {'tweet_mode': 'extended'},
+        {'count': '100', 'tweet_mode': 'extended'},
       ),
     )).thenAnswer(
       (_) async => Response(


### PR DESCRIPTION
Hello 👋🏾 , I noticed that you were missing the `count` parameter when adding parameters to the `retweets` service and, it caused the API to return a random of retweets even if the count was specified. I hope this helps 🙂