### PR TITLE
Now explicitly using en_US for parsing dates

### DIFF
--- a/lib/src/utils/date_utils.dart
+++ b/lib/src/utils/date_utils.dart
@@ -13,7 +13,7 @@ DateTime? convertTwitterDateTime(String? twitterDateString) {
   } catch (e) {
     try {
       final dateString = formatTwitterDateString(twitterDateString);
-      return DateFormat('E MMM dd HH:mm:ss yyyy').parse(dateString, true);
+      return DateFormat('E MMM dd HH:mm:ss yyyy', 'en_US').parse(dateString, true);
     } catch (e) {
       return null;
     }


### PR DESCRIPTION
Twitter only sends back dates in an `en_US` (ish) format, but having the locale of the Dart environment set up to something else (e.g. `fr`) causes this date parsing to fail, and returns `null`.

This solves that issue by ensuring all parsing of dates coming back from Twitter happen using the `en_US` locale.