### PR TITLE
Fix: Add explicit toJson to EditControl

### DIFF
--- a/lib/api/common/data/edit_control.dart
+++ b/lib/api/common/data/edit_control.dart
@@ -20,6 +20,7 @@ class EditControlData {
 }
 
 @JsonSerializable(
+  explicitToJson: true,
   fieldRename: FieldRename.snake,
 )
 class InitialInfo {
@@ -40,6 +41,7 @@ class InitialInfo {
 }
 
 @JsonSerializable(
+  explicitToJson: true,
   fieldRename: FieldRename.snake,
 )
 class EditedInfo {

--- a/lib/api/common/data/edit_control.g.dart
+++ b/lib/api/common/data/edit_control.g.dart
@@ -51,6 +51,6 @@ EditedInfo _$EditedInfoFromJson(Map<String, dynamic> json) {
 
 Map<String, dynamic> _$EditedInfoToJson(EditedInfo instance) =>
     <String, dynamic>{
-      'edit_control_initial': instance.editControlInitial,
+      'edit_control_initial': instance.editControlInitial?.toJson(),
       'initial_tweet_id': instance.initialTweetId,
     };


### PR DESCRIPTION
Hey! @robertodoering I found last minute change which introduced a bug. There is missing explicitToJson on objects, so they can be nested fine as in edited case do.

Can I ask you to merge this with Update. Thank you ❤️ 